### PR TITLE
Enable support for only 'long options'

### DIFF
--- a/lib/getopt.js
+++ b/lib/getopt.js
@@ -88,9 +88,9 @@ goBasicParser.prototype.parseOptstr = function (optstr)
 		chr = optstr[ii];
 		arg = false;
 
-		if (!/^[\w\d]$/.test(chr))
+		if (!/^[\w\d\u1000-\u1100]$/.test(chr))
 			throw (goError('invalid optstring: only alphanumeric ' +
-			    'characters may be used as options: ' + chr));
+			    'characters and unicode characters between \\u1000-\\u1100 may be used as options: ' + chr));
 
 		if (ii + 1 < optstr.length && optstr[ii + 1] == ':') {
 			arg = true;

--- a/tests/test-getopt.js
+++ b/tests/test-getopt.js
@@ -50,7 +50,25 @@ var test_cases = [ {
 	optstr: ':la:r(recurse)(recur)f:(file)(filename)q',
 	argv: [],
 	result: []
-} ];
+}, {
+	optstr: '\u1000(help)\u1001(version)',
+	argv: ['cmd', 'script', '--help' ],
+	result: [
+	   { option: '\u1000' },
+	]
+}, {
+	optstr: '\u1000(help)\u1001(version)',
+	argv: ['cmd', 'script', '--version' ],
+	result: [
+	   { option: '\u1001' },
+	]
+}, {
+	optstr: '\u1000:(parallel)',
+	argv: ['cmd', 'script', '--parallel=100' ],
+	result: [
+	   { option: '\u1000', optarg: 100 },
+	]
+}];
 
 var parser, ii, arg, result;
 for (ii = 0; ii < test_cases.length; ii++) {


### PR DESCRIPTION
Similar to POSIX's getopt_long() custom of using (CHAR_MAX+1) to
denote long options which have no short option equivalent,
allow specific (arbitrary) range of unicode characters to denote
long options.
(POSIX example: http://lingrok.org/xref/coreutils/src/sort.c#539 )

See tests for a usage example.
