### PR TITLE
fix(getopt.js): change type assertions to not use constructor

### DIFF
--- a/lib/getopt.js
+++ b/lib/getopt.js
@@ -39,9 +39,9 @@ function goBasicParser(optstring, argv, optind)
 	var ii;
 
 	ASSERT(optstring || optstring === '', 'optstring is required');
-	ASSERT(optstring.constructor === String, 'optstring must be a string');
+	ASSERT(typeof optstring === 'string', 'optstring must be a string');
 	ASSERT(argv, 'argv is required');
-	ASSERT(argv.constructor === Array, 'argv must be an array');
+	ASSERT(Array.isArray(argv), 'argv must be an array');
 
 	this.gop_argv = new Array(argv.length);
 	this.gop_options = {};
@@ -50,7 +50,7 @@ function goBasicParser(optstring, argv, optind)
 	this.gop_subind = 0;
 
 	for (ii = 0; ii < argv.length; ii++) {
-		ASSERT(argv[ii].constructor === String,
+		ASSERT(typeof argv[ii] === 'string',
 		    'argv must be string array');
 		this.gop_argv[ii] = argv[ii];
 	}


### PR DESCRIPTION
In some cases, such as in the following minimal repro:

```js
'use strict';

const { createContext, runInContext } = require('node:vm');

runInContext(`
'use strict';
const parser = new (require('posix-getopt')).BasicParser('h(help)', [ 'node', 'bin' ]);
`, createContext({ require }));
```

Types such as `Array` will throw if validated by using the constructor. Changing `constructor` for type validation to `typeof` and `Array.isArray` will be a more portable option to avoid issues with constructor symbols from different contexts.